### PR TITLE
Handle wrapper memory corruption

### DIFF
--- a/src/raffle/raffle.py
+++ b/src/raffle/raffle.py
@@ -303,12 +303,20 @@ class Geom_Rw(f90wrap.runtime.FortranModule):
             idx_list = []
             for i in range(self.nspec):
                 name = str(self.spec[i].name.decode()).strip()
+                print("atom name", name)
+                print("positions:", self.spec[i].atom)
+                print("atom_idxs:", self.spec[i].atom_idx)
+                print("num:", self.spec[i].num)
+                print("type:", type(self.spec[i].atom))
+                print("type:", type(self.spec[i].atom_idx))
                 for j in range(self.spec[i].num):
                     symbols.append(name)
                     positions.append(self.spec[i].atom[j][:3])
                     idx_list.append(self.spec[i].atom_idx[j] - 1)
 
-
+            # print type of idx_list
+            print("type(idx_list)", type(idx_list))
+            print("idx_list", idx_list)
             # Check if the length of set(idx_list) is equal to the number of atoms
             if len(set(idx_list)) == self.natom:
                 # Reorder the positions and symbols according to the atom indices
@@ -1900,6 +1908,9 @@ class Generator(f90wrap.runtime.FortranModule):
             if ( exit_code != 0 and exit_code != None ) and not return_exit_code:
                 raise RuntimeError(f"Interface generation failed (exit code {exit_code})")
 
+            print("RAFFLE exit code:", exit_code)
+            print("Number of structures:", num_structures)
+            print("Total number of RAFFLE structures:", self.num_structures)
             structures = self.get_structures(calc)[-num_structures:]
             if return_exit_code:
                 return structures, exit_code

--- a/src/raffle/raffle.py
+++ b/src/raffle/raffle.py
@@ -379,6 +379,10 @@ class Geom_Rw(f90wrap.runtime.FortranModule):
             Parameters:
                 calculator (ASE Calculator):
                     ASE calculator object to be assigned to the Atoms object.
+                return_none_on_failure (bool):
+                    Boolean whether to return None on failure.
+                    If True, return None instead of raising an exception.
+                    If False, raise an exception on failure.
             """
 
             # Set the species list

--- a/src/raffle/raffle.py
+++ b/src/raffle/raffle.py
@@ -402,15 +402,6 @@ class Geom_Rw(f90wrap.runtime.FortranModule):
                     else:
                         raise ValueError(f"Number of atoms in species {name} ({self.spec[i].num}) does not match the row count in atom array ({self.spec[i].atom.shape[0]})")
 
-                print("atom name", name)
-                print("positions:", self.spec[i].atom)
-                print("atom_idxs:", self.spec[i].atom_idx)
-                print("num:", self.spec[i].num)
-                print("positions type:", type(self.spec[i].atom))
-                print("positions dtype:", self.spec[i].atom.dtype)
-                print("index type:", type(self.spec[i].atom_idx))
-                print("index dtype:", self.spec[i].atom_idx.dtype)
-
                 # Process atom positions - require valid data, no fallbacks
                 try:
                     atoms = numpy.asarray(self.spec[i].atom, dtype=numpy.float32)
@@ -2111,9 +2102,6 @@ class Generator(f90wrap.runtime.FortranModule):
             if ( exit_code != 0 and exit_code != None ) and not return_exit_code:
                 raise RuntimeError(f"Interface generation failed (exit code {exit_code})")
 
-            print("RAFFLE exit code:", exit_code)
-            print("Number of structures:", num_structures)
-            print("Total number of RAFFLE structures:", self.num_structures)
             structures = self.get_structures(calc)[-num_structures:]
             if return_exit_code:
                 return structures, exit_code

--- a/src/raffle/raffle.py
+++ b/src/raffle/raffle.py
@@ -323,8 +323,10 @@ class Geom_Rw(f90wrap.runtime.FortranModule):
                 print("positions:", self.spec[i].atom)
                 print("atom_idxs:", self.spec[i].atom_idx)
                 print("num:", self.spec[i].num)
-                print("type:", type(self.spec[i].atom))
-                print("type:", type(self.spec[i].atom_idx))
+                print("positions type:", type(self.spec[i].atom))
+                print("positions dtype:", self.spec[i].atom.dtype)
+                print("index type:", type(self.spec[i].atom_idx))
+                print("index dtype:", self.spec[i].atom_idx.dtype)
                 atoms = numpy.asarray(self.spec[i].atom, dtype=numpy.float32)
                 for j in range(self.spec[i].num):
                     try:

--- a/src/raffle/raffle.py
+++ b/src/raffle/raffle.py
@@ -73,19 +73,23 @@ class Geom_Rw(f90wrap.runtime.FortranModule):
 
                 shape = tuple(array_shape[:array_ndim])
 
+                # Use composite key (handle + type identifier) to prevent collisions
+                cache_key = (array_handle, 'atom_idx')
+
                 # Validate expected dimensions
                 if array_ndim != 1:
                     print(f"Warning: atom_idx has incorrect dimension from Fortran: {array_ndim}, expected 1")
                     return numpy.array([j+1 for j in range(self.num)], dtype=numpy.int32)
 
-                if array_handle in self._arrays:
-                    atom_idx = self._arrays[array_handle]
+
+                if cache_key in self._arrays:
+                    atom_idx = self._arrays[cache_key]
                 else:
                     atom_idx = f90wrap.runtime.get_array(f90wrap.runtime.sizeof_fortran_t,
                                             self._handle,
                                             _raffle.f90wrap_species_type__array__atom_idx)
                     # Store a copy to avoid potential corruption from view operations
-                    self._arrays[array_handle] = atom_idx.copy()
+                    self._arrays[cache_key] = atom_idx.copy()
 
                 # Convert to proper integer type but check for corruption first
                 try:
@@ -136,14 +140,17 @@ class Geom_Rw(f90wrap.runtime.FortranModule):
 
                 shape = tuple(array_shape[:array_ndim])
 
-                if array_handle in self._arrays:
-                    atom = self._arrays[array_handle]
+                # Use composite key (handle + type identifier) to prevent collisions
+                cache_key = (array_handle, 'atom')
+
+                if cache_key in self._arrays:
+                    atom = self._arrays[cache_key]
                 else:
                     atom = f90wrap.runtime.get_array(f90wrap.runtime.sizeof_fortran_t,
                                             self._handle,
                                             _raffle.f90wrap_species_type__array__atom)
                     # Store a copy to avoid potential corruption from view operations
-                    self._arrays[array_handle] = atom.copy()
+                    self._arrays[cache_key] = atom.copy()
 
                 # Convert to proper float type but check for corruption first
                 try:
@@ -615,8 +622,10 @@ class Geom_Rw(f90wrap.runtime.FortranModule):
 
             shape = tuple(array_shape[:array_ndim])
 
-            if array_handle in self._arrays:
-                lat = self._arrays[array_handle]
+            # Use composite key (handle + type identifier) to prevent collisions
+            cache_key = (array_handle, 'lat')
+            if cache_key in self._arrays:
+                lat = self._arrays[cache_key]
             else:
                 lat = f90wrap.runtime.get_array(f90wrap.runtime.sizeof_fortran_t,
                                         self._handle,
@@ -624,7 +633,8 @@ class Geom_Rw(f90wrap.runtime.FortranModule):
 
                 lat = lat.view(numpy.float32).reshape(shape, order='A')
 
-                self._arrays[array_handle] = lat
+                # Store a copy to avoid potential corruption from view operations
+                self._arrays[cache_key] = lat
             return lat
 
         @lat.setter
@@ -649,13 +659,16 @@ class Geom_Rw(f90wrap.runtime.FortranModule):
             """
             array_ndim, array_type, array_shape, array_handle = \
                 _raffle.f90wrap_basis_type__array__pbc(self._handle)
-            if array_handle in self._arrays:
-                pbc = self._arrays[array_handle]
+            # Use composite key (handle + type identifier) to prevent collisions
+            cache_key = (array_handle, 'pbc')
+            if cache_key in self._arrays:
+                pbc = self._arrays[cache_key]
             else:
                 pbc = f90wrap.runtime.get_array(f90wrap.runtime.sizeof_fortran_t,
                                         self._handle,
                                         _raffle.f90wrap_basis_type__array__pbc)
-                self._arrays[array_handle] = pbc
+                # Store a copy to avoid potential corruption from view operations
+                self._arrays[cache_key] = pbc
             return pbc
 
         @pbc.setter


### PR DESCRIPTION
## Changed:
- Return `None` from `toase()` on fail
- Improve handling of type mismatch in `toase`

----

Cannot currently find the source of the memory corruption that seems to happen sometimes in RAFFLE AGOX runs.

Safeguards and checks are implemented, and improved type assignment.

To fix this for now, `toase()` will return `None` by default if it encounters an error and print warnings.